### PR TITLE
Skip running tests when building on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                                  string(credentialsId: 'gpg-passphrase', variable: 'GPG_PASSPHRASE'),
                                  usernamePassword(credentialsId: 'maven-central', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'gpg --import ${GPG_PRIVATE_KEY}'
-                    sh "mvn --batch-mode -Dgpg.passphrase='${GPG_PASSPHRASE}' -Dserver.id=ossrh -Dserver.username=${USERNAME} -Dserver.password='${PASSWORD}' clean deploy"
+                    sh "mvn --batch-mode -DskipTests -Dgpg.passphrase='${GPG_PASSPHRASE}' -Dserver.id=ossrh -Dserver.username=${USERNAME} -Dserver.password='${PASSWORD}' clean deploy"
                 }
             }
         }


### PR DESCRIPTION
I suggest disabling tests on Jenkins to verify that the job works in all other aspects. Configuring the source project and Jenkins environment for headless gui tests can be done later and when it is complete we can revert this change.